### PR TITLE
Use curly brace literal instead of dict function

### DIFF
--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -106,7 +106,7 @@ class Pushbullet(object):
 
     @staticmethod
     def _recipient(device=None, chat=None, email=None, channel=None):
-        data = dict()
+        data = {}
         if device:
             data["device_iden"] = device.device_iden
         elif chat:


### PR DESCRIPTION
I know it's a silly little change. Though, surely it is _better_ to use the literal syntax?