### PR TITLE
Remove download shield and fix pypi link

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -7,11 +7,8 @@ pushbullet.py
 .. image:: https://img.shields.io/coveralls/randomchars/pushbullet.py.svg?style=flat-square
     :target: https://coveralls.io/r/randomchars/pushbullet.py
 
-.. image:: https://img.shields.io/pypi/dm/pushbullet.py.svg?style=flat-square
-    :target: https://pypi.python.org/pypi?name=pushbullet.py&:action=display
-
 .. image:: https://img.shields.io/pypi/v/pushbullet.py.svg?style=flat-square
-    :target: https://pypi.python.org/pypi?name=pushbullet.py&:action=display
+    :target: https://pypi.org/project/pushbullet.py/
 
 .. image:: https://img.shields.io/pypi/l/pushbullet.py.svg
 


### PR DESCRIPTION
The pypi downloads shield no longer works so might as well remove it. https://github.com/badges/shields/issues/716

Also updated the project's pypi url.