### PR TITLE
Fix file type detection, rate limit headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,141 @@
-*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
 dist/
-pushbullet.py.egg-info/
-.env
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# macOS
+.DS_Store

--- a/pushbullet/channel.py
+++ b/pushbullet/channel.py
@@ -18,14 +18,6 @@ class Channel(object):
         data = {"type": "note", "title": title, "body": body}
         return self._push(data)
 
-    def push_address(self, name, address):
-        warnings.warn("Address push type is removed. This push will be sent as note.")
-        return self.push_note(name, address)
-
-    def push_list(self, title, items):
-        warnings.warn("List push type is removed. This push will be sent as note.")
-        return self.push_note(title, ",".join(items))
-
     def push_link(self, title, url, body=None):
         data = {"type": "link", "title": title, "url": url, "body": body}
         return self._push(data)

--- a/pushbullet/device.py
+++ b/pushbullet/device.py
@@ -21,14 +21,6 @@ class Device(object):
         data = {"type": "note", "title": title, "body": body}
         return self._push(data)
 
-    def push_address(self, name, address):
-        warnings.warn("Address push type is removed. This push will be sent as note.")
-        return self.push_note(name, address)
-
-    def push_list(self, title, items):
-        warnings.warn("List push type is removed. This push will be sent as note.")
-        return self.push_note(title, ",".join(items))
-
     def push_link(self, title, url, body=None):
         data = {"type": "link", "title": title, "url": url, "body": body}
         return self._push(data)

--- a/pushbullet/errors.py
+++ b/pushbullet/errors.py
@@ -6,3 +6,9 @@ class InvalidKeyError(PushbulletError):
 
 class PushError(PushbulletError):
     pass
+
+
+class NoEncryptionModuleError(Exception):
+    def __init__(self, msg):
+        super(NoEncryptionModuleError, self).__init__(
+            "cryptography is required for end-to-end encryption support and could not be imported: " + msg + "\nYou can install it by running 'pip install cryptography'")

--- a/pushbullet/filetype.py
+++ b/pushbullet/filetype.py
@@ -1,11 +1,17 @@
-def _magic_get_file_type(f, _):
-    file_type = magic_from_buffer(f.read(1024), mime=True)
-    f.seek(0)
-    return maybe_decode(file_type)
+
+try:
+    from magic import from_buffer as magic_from_buffer
+except ImportError:
+    import mimetypes
 
 
-def _guess_file_type(_, filename):
-    return mimetypes.guess_type(filename)[0]
+def get_file_type(file, filename):
+    try:
+        file_type = magic_from_buffer(file.read(1024), mime=True)
+        file.seek(0)
+        return maybe_decode(file_type)
+    except NameError:
+        return mimetypes.guess_type(filename)[0]
 
 
 # return str on python3.  Don't want to unconditionally
@@ -17,11 +23,3 @@ def maybe_decode(s):
         decoded = s
     return decoded
 
-
-try:
-    from magic import from_buffer as magic_from_buffer
-except ImportError:
-    import mimetypes
-    get_file_type = _guess_file_type
-else:
-    get_file_type = _magic_get_file_type

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -2,19 +2,14 @@ import os
 import json
 import requests
 import warnings
+from requests import ConnectionError
 
 from .device import Device
 from .channel import Channel
 from .chat import Chat
-from .errors import PushbulletError, InvalidKeyError, PushError
+from .errors import PushbulletError, InvalidKeyError, PushError, NoEncryptionModuleError
 from .filetype import get_file_type
 from ._compat import standard_b64encode
-
-
-class NoEncryptionModuleError(Exception):
-    def __init__(self, msg):
-        super(NoEncryptionModuleError, self).__init__(
-            "cryptography is required for end-to-end encryption support and could not be imported: " + msg + "\nYou can install it by running 'pip install cryptography'")
 
 
 class Pushbullet(object):

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -271,9 +271,9 @@ class Pushbullet(object):
         r = self._session.post(self.PUSH_URL, data=json.dumps(data))
         if r.status_code == requests.codes.ok:
             js = r.json()
-            js['Ratelimit-Reset'] = r.headers['X-Ratelimit-Reset']
-            js['Ratelimit-Limit'] = r.headers['X-Ratelimit-Limit']
-            js['Ratelimit-Remaining'] = r.headers['X-Ratelimit-Remaining']
+            js['Ratelimit-Reset'] = r.headers.get('X-Ratelimit-Reset')
+            js['Ratelimit-Limit'] = r.headers.get('X-Ratelimit-Limit')
+            js['Ratelimit-Remaining'] = r.headers.get('X-Ratelimit-Remaining')
             return js
         else:
             raise PushError(r.text)

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -271,9 +271,12 @@ class Pushbullet(object):
         r = self._session.post(self.PUSH_URL, data=json.dumps(data))
         if r.status_code == requests.codes.ok:
             js = r.json()
-            js['Ratelimit-Reset'] = r.headers.get('X-Ratelimit-Reset')
-            js['Ratelimit-Limit'] = r.headers.get('X-Ratelimit-Limit')
-            js['Ratelimit-Remaining'] = r.headers.get('X-Ratelimit-Remaining')
+            rate_limit = {}
+            rate_limit['reset'] = r.headers.get('X-Ratelimit-Reset')
+            rate_limit['limit'] = r.headers.get('X-Ratelimit-Limit')
+            rate_limit['remaining'] = r.headers.get('X-Ratelimit-Remaining')
+
+            js["rate_limit"] = rate_limit
             return js
         else:
             raise PushError(r.text)


### PR DESCRIPTION
What does this PR do?

- Response no longer fails if rate limit headers are missing
- Rate limit info is now under `rate_limit` property
- Removed deprecated `push_address` and `push_list` methods 
- Adds a `gitignore` from GitHub